### PR TITLE
Improved Matomo settings configuration and added localization support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,34 +16,63 @@ composer require rocramer/nova-matomo-analytics
 After that you can register the following metrics on a dashboard of your choice:
 
 ```php
-    protected function cards()
-    {
-        return [
-            new \Rocramer\MatomoAnalytics\Cards\UniqueVisitors(),
-            new \Rocramer\MatomoAnalytics\Cards\Visits(),
-            new \Rocramer\MatomoAnalytics\Cards\VisitLength(),
-            new \Rocramer\MatomoAnalytics\Cards\BounceRate(),
-            new \Rocramer\MatomoAnalytics\Cards\Outlinks(),
-            new \Rocramer\MatomoAnalytics\Cards\Downloads()
-        ];
-    }
+protected function cards()
+{
+    return [
+        new \Rocramer\MatomoAnalytics\Cards\UniqueVisitors(),
+        new \Rocramer\MatomoAnalytics\Cards\Visits(),
+        new \Rocramer\MatomoAnalytics\Cards\VisitLength(),
+        new \Rocramer\MatomoAnalytics\Cards\BounceRate(),
+        new \Rocramer\MatomoAnalytics\Cards\Outlinks(),
+        new \Rocramer\MatomoAnalytics\Cards\Downloads()
+    ];
+}
 ```
 
-The plugin requires your Matomo url, token and side id in your .env file:
+The plugin requires your Matomo url, token and side id in your `config/services.php` file:
 
-```
-MATOMO_URL=https://analytics.example.com/
-MATOMO_TOKEN=8axxxxxxxxxxxxxxxxxxxx35a5a
-MATOMO_PAGE_ID=1
+```php
+'matomo' => [
+    'token'   => env('MATOMO_TOKEN'),
+    'url'     => env('MATOMO_URL'),
+    'page_id' => env('MATOMO_PAGE_ID')
+]
 ```
 
 This is a first version. More Nova Cards and an own dashboard for Matomo metrics are planned for the future.
 
 Feel free to create a PR or contribute suggestions.
 
-## Misc.
+## Customization
 
-Keep in mind: All cards get cached for 5 minutes.
+### Caching
+
+By default, all cards get cached for 5 minutes. You can change that behaviour by adding a `caching` setting with the number of minutes you want to cache within your `config/services.php` file: 
+
+```php
+'matomo' => [
+    'token'   => env('MATOMO_TOKEN'),
+    'url'     => env('MATOMO_URL'),
+    'page_id' => env('MATOMO_PAGE_ID'),
+    'caching' => 3
+]
+```
+
+If you want to fully disable caching for the cards, just set the value to `false`.
+
+### Localization
+
+This package uses localization via [Laravel Translation Strings](https://laravel.com/docs/5.7/localization#retrieving-translation-strings). Therefore, you can add localization support for your cards by adding the keys with their corresponding translations to your JSON localization files. So, for German language support add the following keys in `resources/lang/vendor/nova/de.json`:
+```json
+"Unique Visitors": "Eindeutige Besucher",
+"Visits": "Aufrufe",
+"Visit Length": "Besuchsdauer",
+"Outlinks": "Ausgehende Verweise",
+"Bounce Rate": "Absprungrate",
+"Downloads": "Downloads",
+"seconds (avg.)": "Sekunden (Durchschnitt)",
+"Days": "Tage",
+```
 
 ## License
 

--- a/src/Cards/BounceRate.php
+++ b/src/Cards/BounceRate.php
@@ -42,32 +42,7 @@ class BounceRate extends CustomizedTrend
         return (new TrendResult())
             ->trend($results)
             ->showLatestValue()
-            ->suffix('percent');
-    }
-
-    /**
-     * Get the ranges available for the metric.
-     *
-     * @return array
-     */
-    public function ranges()
-    {
-        return [
-            7  => '7 Days',
-            14 => '14 Days',
-            30 => '30 Days',
-            90 => '90 Days',
-        ];
-    }
-
-    /**
-     * Determine for how many minutes the metric should be cached.
-     *
-     * @return \DateTimeInterface|\DateInterval|float|int
-     */
-    public function cacheFor()
-    {
-        return now()->addMinutes(5);
+            ->suffix('%');
     }
 
     /**

--- a/src/Cards/Downloads.php
+++ b/src/Cards/Downloads.php
@@ -30,31 +30,6 @@ class Downloads extends CustomizedTrend
     }
 
     /**
-     * Get the ranges available for the metric.
-     *
-     * @return array
-     */
-    public function ranges()
-    {
-        return [
-            7  => '7 Days',
-            14 => '14 Days',
-            30 => '30 Days',
-            90 => '90 Days',
-        ];
-    }
-
-    /**
-     * Determine for how many minutes the metric should be cached.
-     *
-     * @return \DateTimeInterface|\DateInterval|float|int
-     */
-    public function cacheFor()
-    {
-        return now()->addMinutes(5);
-    }
-
-    /**
      * Get the URI key for the metric.
      *
      * @return string

--- a/src/Cards/Outlinks.php
+++ b/src/Cards/Outlinks.php
@@ -30,31 +30,6 @@ class Outlinks extends CustomizedTrend
     }
 
     /**
-     * Get the ranges available for the metric.
-     *
-     * @return array
-     */
-    public function ranges()
-    {
-        return [
-            7  => '7 Days',
-            14 => '14 Days',
-            30 => '30 Days',
-            90 => '90 Days',
-        ];
-    }
-
-    /**
-     * Determine for how many minutes the metric should be cached.
-     *
-     * @return \DateTimeInterface|\DateInterval|float|int
-     */
-    public function cacheFor()
-    {
-        return now()->addMinutes(5);
-    }
-
-    /**
      * Get the URI key for the metric.
      *
      * @return string

--- a/src/Cards/UniqueVisitors.php
+++ b/src/Cards/UniqueVisitors.php
@@ -30,31 +30,6 @@ class UniqueVisitors extends CustomizedTrend
     }
 
     /**
-     * Get the ranges available for the metric.
-     *
-     * @return array
-     */
-    public function ranges()
-    {
-        return [
-            7  => '7 Days',
-            14 => '14 Days',
-            30 => '30 Days',
-            90 => '90 Days',
-        ];
-    }
-
-    /**
-     * Determine for how many minutes the metric should be cached.
-     *
-     * @return \DateTimeInterface|\DateInterval|float|int
-     */
-    public function cacheFor()
-    {
-        return now()->addMinutes(5);
-    }
-
-    /**
      * Get the URI key for the metric.
      *
      * @return string

--- a/src/Cards/VisitLength.php
+++ b/src/Cards/VisitLength.php
@@ -42,32 +42,7 @@ class VisitLength extends CustomizedTrend
         return (new TrendResult())
             ->trend($results)
             ->showLatestValue()
-            ->suffix('seconds (avg.)');
-    }
-
-    /**
-     * Get the ranges available for the metric.
-     *
-     * @return array
-     */
-    public function ranges()
-    {
-        return [
-            7  => '7 Days',
-            14 => '14 Days',
-            30 => '30 Days',
-            90 => '90 Days',
-        ];
-    }
-
-    /**
-     * Determine for how many minutes the metric should be cached.
-     *
-     * @return \DateTimeInterface|\DateInterval|float|int
-     */
-    public function cacheFor()
-    {
-        return now()->addMinutes(5);
+            ->suffix(__('seconds (avg.)'));
     }
 
     /**

--- a/src/Cards/Visits.php
+++ b/src/Cards/Visits.php
@@ -30,31 +30,6 @@ class Visits extends CustomizedTrend
     }
 
     /**
-     * Get the ranges available for the metric.
-     *
-     * @return array
-     */
-    public function ranges()
-    {
-        return [
-            7  => '7 Days',
-            14 => '14 Days',
-            30 => '30 Days',
-            90 => '90 Days',
-        ];
-    }
-
-    /**
-     * Determine for how many minutes the metric should be cached.
-     *
-     * @return \DateTimeInterface|\DateInterval|float|int
-     */
-    public function cacheFor()
-    {
-        return now()->addMinutes(5);
-    }
-
-    /**
      * Get the URI key for the metric.
      *
      * @return string

--- a/src/CustomizedTrend.php
+++ b/src/CustomizedTrend.php
@@ -15,6 +15,15 @@ abstract class CustomizedTrend extends Trend
     public $component = 'custom-trend-metric';
 
     /**
+     * Get the displayable name of the metric.
+     *
+     * @return string
+     */
+    public function name() {
+        return __(parent::name());
+    }
+
+    /**
      * Create a new trend metric result.
      *
      * @param string|null $value
@@ -24,5 +33,34 @@ abstract class CustomizedTrend extends Trend
     public function result($value = null)
     {
         return new TrendResult($value);
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [
+            7  => '7 ' . __('Days'),
+            14 => '14 ' . __('Days'),
+            30 => '30 ' . __('Days'),
+            90 => '90 ' . __('Days'),
+        ];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        if ($cacheMinutes = config('services.matomo.caching', 5)) {
+            return now()->addMinutes($cacheMinutes);
+        }
+
+        return null;
     }
 }

--- a/src/Helper/MatomoAPI.php
+++ b/src/Helper/MatomoAPI.php
@@ -15,9 +15,9 @@ class MatomoAPI
      */
     public static function url(string $method, int $date = 7, string $segment = null): string
     {
-        $token_auth = config('services.matomo.token');
-        $page_id = config('services.matomo.page_id');
-        $url = config('services.matomo.url');
+        $token_auth = config('services.matomo.token', env('MATOMO_TOKEN'));
+        $page_id = config('services.matomo.page_id', env('MATOMO_PAGE_ID'));
+        $url = config('services.matomo.url', env('MATOMO_URL'));
 
         $url .= "?module=API&method=$method";
         $url .= "&idSite=$page_id&period=day&date=last$date";

--- a/src/Helper/MatomoAPI.php
+++ b/src/Helper/MatomoAPI.php
@@ -15,9 +15,9 @@ class MatomoAPI
      */
     public static function url(string $method, int $date = 7, string $segment = null): string
     {
-        $token_auth = env('MATOMO_TOKEN');
-        $page_id = env('MATOMO_PAGE_ID');
-        $url = env('MATOMO_URL');
+        $token_auth = config('services.matomo.token');
+        $page_id = config('services.matomo.page_id');
+        $url = config('services.matomo.url');
 
         $url .= "?module=API&method=$method";
         $url .= "&idSite=$page_id&period=day&date=last$date";


### PR DESCRIPTION
- Added localization support using Laravel's translation strings
- Improved the Matomo settings configuration by adding the config settings to the `config/services.php` file. This enables each project to have different keys in their `.env` file. I also added a fallback to the plain `.env` config values to make this a non-breaking change
- Refactored the card classes by moving the functions `ranges()`and `cacheFor()`to the parent class `CustomizedTrend`, since these classes all implemented the same code
- Updated the `readme.md`with the changes