### PR TITLE
Only perform calculations if value exists

### DIFF
--- a/src/Cards/BounceRate.php
+++ b/src/Cards/BounceRate.php
@@ -30,9 +30,11 @@ class BounceRate extends CustomizedTrend
         $keys = array_keys($bounce_count);
 
         foreach ($keys as $key) {
-            $value = $bounce_count[$key] / $visits[$key] * 100;
-            $value = (int) round($value);
-            $results[$key] = $value;
+            if ($visits[$key]) {
+                $value = $bounce_count[$key] / $visits[$key] * 100;
+                $value = (int) round($value);
+                $results[$key] = $value;
+            }
         }
 
         return (new TrendResult())

--- a/src/Cards/VisitLength.php
+++ b/src/Cards/VisitLength.php
@@ -30,9 +30,11 @@ class VisitLength extends CustomizedTrend
         $keys = array_keys($visit_length);
 
         foreach ($keys as $key) {
-            $value = $visit_length[$key] / $visits[$key];
-            $value = (int) round($value);
-            $results[$key] = $value;
+            if ($visits[$key]) {
+                $value = $visit_length[$key] / $visits[$key];
+                $value = (int) round($value);
+                $results[$key] = $value;
+            }
         }
 
         return (new TrendResult())


### PR DESCRIPTION
*Summary*
I kept getting the exception `ErrorException(code: 0): Division by zero`, in `VisitLength.php` and `BounceRate.php`. I updated those cards to only perform the calculation if a value exists for a particular key, to avoid the division by 0 and subsequent error.