### PR TITLE
Add 'flat' flag to actions requests

### DIFF
--- a/src/Helper/MatomoAPI.php
+++ b/src/Helper/MatomoAPI.php
@@ -55,6 +55,7 @@ class MatomoAPI
         $url .= "&idSite=$page_id&period=range&date=$from,$till";
         $url .= '&format=json';
         $url .= '&filter_limit=10';
+        $url .= '&flat=1';
         $url .= "&token_auth=$token_auth";
 
         return Http::get($url)->json();


### PR DESCRIPTION
Currently subpages are grouped under the first level page (on the entry pages, exit pages and most viewed pages widgets).
Using the `flat=1` flag splits out those pages.